### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
 
 name: Build benthos
+permissions:
+  contents: write
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/CMiguelRB/benthos/security/code-scanning/3](https://github.com/CMiguelRB/benthos/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the workflow level to define the least privileges required for the workflow. Based on the workflow's actions, it needs `contents: read` to check out the repository and `contents: write` to create a release. We will add the following permissions block:

```yaml
permissions:
  contents: write
```

This block will be added at the root of the workflow, applying to all jobs unless overridden by a job-specific `permissions` block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
