### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -3,6 +3,9 @@
 
 name: Build benthos
 
+permissions:
+  contents: read
+
 on:
   pull_request: 
     branches: 


### PR DESCRIPTION
Potential fix for [https://github.com/CMiguelRB/benthos/security/code-scanning/1](https://github.com/CMiguelRB/benthos/security/code-scanning/1)

To fix the issue, add a `permissions` block to the workflow to explicitly limit the permissions of the `GITHUB_TOKEN`. Since the workflow only runs tests and does not require write access, the permissions can be set to `contents: read`. This ensures the workflow has the minimal permissions necessary to complete its tasks securely.

The `permissions` block should be added at the root level of the workflow to apply to all jobs, as there is only one job (`test`) in this workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
